### PR TITLE
Transfer the configs' strings to localization file

### DIFF
--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -1,5 +1,16 @@
 ﻿Mods: {
 	Verdant: {
+		Configs : {
+			HeadLabel : Verdant Client Configuration
+			EnableSteamEffectLabel : Enable Steam Effect
+			EnableSteamEffectTooltip : Enables steam overlay when inside of the underground Verdant.
+			EnableForeOrBackgroundObjectsLabel : Enable Foreground/Background Objects
+			EnableForeOrBackgroundObjectsTooltip : Enables decoration objects appearing in the surface background or foreground everywhere.
+			EnableCustomWaterfallsLabel : Enable Custom Waterfalls
+			EnableCustomWaterfallsTooltip : Enables waterfalls appearing from tiles, such as the Weeping Bud.
+			CustomDialogueSystemLabel : Custom Dialogue System
+			CustomDialogueSystemTooltip : Allows the usage of a custom dialogue system for the Apotheosis. If turned off, will just use the chat.
+		}
 		MapObject: {
 			VerdantPylon: Verdant Pylon
 		}

--- a/Systems/ScreenText/ScreenText.cs
+++ b/Systems/ScreenText/ScreenText.cs
@@ -48,7 +48,7 @@ namespace Verdant.Systems.ScreenText
 
         public ScreenText(string text, float timeLeft, float scale = 1f, Alignment alignment = Alignment.Center, DrawEffect effect = DrawEffect.None, IScreenTextAnimation anim = null, bool dieAutomatically = true)
         {
-            this.text = text;
+            this.text = VerdantLocalization.ScreenTextLocalization(text);
             this.scale = scale;
             this.alignment = alignment;
             this.effect = effect;

--- a/VerdantConfig.cs
+++ b/VerdantConfig.cs
@@ -9,30 +9,30 @@ namespace Verdant
     //    public override ConfigScope Mode => ConfigScope.ServerSide;
     //}
 
-    [Label("Verdant Client Configuration")]
+    [Label("$Mods.Verdant.Configs.HeadLabel")]
     public class VerdantClientConfig : ModConfig
     {
         public override ConfigScope Mode => ConfigScope.ClientSide;
 
         [DefaultValue(true)]
-        [Label("Enable Steam Effect")]
-        [Tooltip("Enables steam overlay when inside of the underground Verdant.")]
+        [Label("$Mods.Verdant.Configs.EnableSteamEffectLabel")]
+        [Tooltip("$Mods.Verdant.Configs.EnableSteamEffectTooltip")]
         public bool EnableSteam;
 
         [DefaultValue(true)]
-        [Label("Enable Foreground/Background Objects")]
-        [Tooltip("Enables decoration objects appearing in the surface background or foreground everywhere.")]
+        [Label("$Mods.Verdant.Configs.EnableForeOrBackgroundObjectsLabel")]
+        [Tooltip("$Mods.Verdant.Configs.EnableForeOrBackgroundObjectsTooltip")]
         public bool BackgroundObjects;
 
         [DefaultValue(true)]
-        [Label("Enable Custom Waterfalls")]
-        [Tooltip("Enables waterfalls appearing from tiles, such as the Weeping Bud.")]
+        [Label("$Mods.Verdant.Configs.EnableCustomWaterfallsLabel")]
+        [Tooltip("$Mods.Verdant.Configs.EnableCustomWaterfallsTooltip")]
         [ReloadRequired]
         public bool Waterfalls;
 
         [DefaultValue(true)]
-        [Label("Custom Dialogue System")]
-        [Tooltip("Allows the usage of a custom dialogue system for the Apotheosis. If turned off, will just use the chat.")]
+        [Label("$Mods.Verdant.Configs.CustomDialogueSystemLabel")]
+        [Tooltip("$Mods.Verdant.Configs.CustomDialogueSystemTooltip")]
         public bool CustomDialogue;
     }
 }

--- a/VerdantLocalization
+++ b/VerdantLocalization
@@ -1,0 +1,8 @@
+namespace Verdant {
+    public class VerdantLocalization {
+        /// <summary>Allow you to use hook to change dialogues and other scree text added by Verdant easily.</summary>
+        public static string ScreenTextLocalization(string text) {
+            return text;
+        }
+    }
+}


### PR DESCRIPTION
Hi，dear GabeHasWon. Thank you for your wonderful tmod which brought us more wonderful content. The tmod players in China really enjoy your interesting and beautiful mod. However，the language gap prevent some people from fully enjoy it. So I want change a little codes to make it more easy to be localized. 
Apart from this change to config, I want to add localization  to the dialogues too. to make it easier, I add Verdantlocalization.cs file and add a little thing in ScreenText's init.